### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/Azreyo/Carbon/security/code-scanning/9](https://github.com/Azreyo/Carbon/security/code-scanning/9)

To fix the problem, an explicit `permissions:` block should be added to the workflow to restrict the privileges given to the `GITHUB_TOKEN`. Because none of the jobs require write access to repository contents or other privileged resources (they only check out code, run tests/builds, and upload artifacts), the recommended minimal permission is `contents: read`. This can be added at the root level to apply to all jobs:

- Insert a block at the top level, after the `name:` or `on:` section (before `jobs:`).
- The block should be:
  ```yaml
  permissions:
    contents: read
  ```
- This will apply to all jobs unless a specific job explicitly overrides with its own `permissions:` block.

No imports, method changes, or complex edits are required—just a YAML block edit in `.github/workflows/ci.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
