### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,5 +1,8 @@
 name: C/C++ CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/Azreyo/Carbon/security/code-scanning/8](https://github.com/Azreyo/Carbon/security/code-scanning/8)

To fix the problem, you should explicitly add a `permissions` block to the workflow. This can be done either at the root of the workflow (applies to all jobs unless overridden) or per job (for job-specific cases). The minimal permissions needed for this workflow are typically `contents: read` (for checking out code) and `actions: read` (if actions metadata is accessed by the runner), but in this workflow, the only place where write access might be necessary is for uploading workflow artifacts. The `actions/upload-artifact` action does not require any special write scope; `contents: read` is enough.

Therefore, the best fix is to add at the root of the workflow (at the top, after `name:` and before `jobs:`):

```yaml
permissions:
  contents: read
```

This restricts the GITHUB_TOKEN to read-only contents actions. If a future job does require write permissions (e.g., opening pull requests, commenting on issues), you can add a job-specific permissions block there. No other code changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
